### PR TITLE
Enforce default blade tags

### DIFF
--- a/src/Jlapp/Swaggervel/routes.php
+++ b/src/Jlapp/Swaggervel/routes.php
@@ -49,5 +49,9 @@ Route::get('api-docs', function() {
             }
         }
     }
+    
+    Blade::setEscapedContentTags('{{{', '}}}');
+    Blade::setContentTags('{{', '}}');
+
     return View::make('swaggervel::index');
 });


### PR DESCRIPTION
Usefull if people use a different set of tags (since angular uses the same tags)
