### PR TITLE
Added config directory to default exclude paths

### DIFF
--- a/src/config/app.php
+++ b/src/config/app.php
@@ -37,6 +37,7 @@ return array(
         app_path()."/storage",
         app_path()."/tests",
         app_path()."/views",
+        app_path()."/config"
     ),
 
     /*


### PR DESCRIPTION
I've come across a nasty problem regarding too much nesting going on.

This was because of the fact that I used mcamara/laravel-localization which ships with quite a large configuration file containing a ton of comments. This resulted in nesting errors, since swagger-php tries to analyze all of those comments as well. Since it shouldn't be necessary to include configuration files in swagger generation anyway, I recommend excluding the directory by default.