### PR TITLE
#56 - Reverting changed that applied to the fork but aren't really applicable to the official package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,13 @@
 Swagger 2
 =========
-This fork uses Swagger-spec 2.0 and Swagger-php 2.0. 
-This fork also updates the Swagger-ui to version 2.1.1.
-
-To use this package, add to the composer.json:
-````
-"repositories": [
-        {
-          "type": "vcs",
-          "url": "https://github.com/tralves/Swaggervel"
-        }
-    ],
-(...)
-"require": {
-  "jlapp/swaggervel": "master-dev",
-}
-````
-
-
-    
+This branch uses Swagger-spec 2.0 and Swagger-php 2.0. 
+This branch also updates the Swagger-ui to version 2.1.1.
 
 OAuth2
 ======
 The Swagger-ui was changed to allow inserting the OAuth 2 parameters (``client_id``, ``client_secret``, ``realm`` and ``appName``) directly in the ui.
 You can also pass these values in the url in the URL, like so:
 ``http://api.appcursos.com/api-docs?client_id=my-client-id&client_secret=my-client-secret&realm=my-realm&appName=my-app-name``
-
-The rest of this document comes from the original (and awesome) package [Swaggervel](https://github.com/slampenny/Swaggervel)
 
 To use Swaggervel for Laravel 4.2, use the version 1.0 branch (https://github.com/slampenny/Swaggervel/tree/1.0)
 

--- a/src/config/swaggervel.php
+++ b/src/config/swaggervel.php
@@ -26,7 +26,7 @@ return array(
       | Absolute path to directory containing the swagger annotations are stored.
       |--------------------------------------------------------------------------
     */
-    "app-dir" => "modules/Api",
+    "app-dir" => "app",
 
     /*
       |--------------------------------------------------------------------------


### PR DESCRIPTION
Addressing #56. Removed composer section pointing to the fork. This is no longer necessary for the official package.

Also changed the config to point back to the app directory instead of modules/Api. A default Laravel instance (or at least in my case) wouldn't have this. I chased my tail a tiny bit trying to get this to work and didn't realize what I was pointing at.
