### PR TITLE
Laravel 5.2 removes the Input facade

### DIFF
--- a/src/Jlapp/Swaggervel/routes.php
+++ b/src/Jlapp/Swaggervel/routes.php
@@ -56,10 +56,10 @@ Route::get('api-docs', function() {
         'secure'         => Request::secure(),
         'urlToDocs'      => url(Config::get('swaggervel.doc-route')),
         'requestHeaders' => Config::get('swaggervel.requestHeaders'),
-        'clientId'       => Input::get("client_id"),
-        'clientSecret'       => Input::get("client_secret"),
-        'realm'       => Input::get("realm"),
-        'appName'       => Input::get("appName"),
+        'clientId'       => Request::input("client_id"),
+        'clientSecret'   => Request::input("client_secret"),
+        'realm'          => Request::input("realm"),
+        'appName'        => Request::input("appName"),
         )
     );
 


### PR DESCRIPTION
It's easily replaced with https://laravel.com/api/5.2/Illuminate/Http/Request.html#method_input that also existed in 5.1 (and likely earlier but I’m too lazy to look it up).

Alternatively there's the [LaravelCollective](https://laravelcollective.com/) that may re-implement this facade in the future.
