### PR TITLE
Issue #61: Prevent doc-dir from being overwritten on each generate

### DIFF
--- a/src/Jlapp/Swaggervel/routes.php
+++ b/src/Jlapp/Swaggervel/routes.php
@@ -21,14 +21,11 @@ Route::get(Config::get('swaggervel.api-docs-route'), function() {
         $appDir = base_path()."/".Config::get('swaggervel.app-dir');
         $docDir = Config::get('swaggervel.doc-dir');
 
-        if (!File::exists($docDir) || is_writable($docDir)) {
-            // delete all existing documentation
-            if (File::exists($docDir)) {
-                File::deleteDirectory($docDir);
-            }
-
+        if (!File::exists($docDir)) {
             File::makeDirectory($docDir);
+        }
 
+        if (is_writable($docDir)) {
             $defaultBasePath = Config::get('swaggervel.default-base-path');
             $defaultApiVersion = Config::get('swaggervel.default-api-version');
             $defaultSwaggerVersion = Config::get('swaggervel.default-swagger-version');


### PR DESCRIPTION
This addresses issue #61.

Reverted to workflow introduced before commit d2b68480f2977e26c3976c2fdb01be03f22a5c91.

Obliterating the directory in the current manner was causing havoc with our deployment. I was erroneously committing the local contents and files generated on the server would typically be newer, causing the deployment to break. This change allows a local .gitignore to follow the convention set in other storage directories, preventing the need to touch the project-wide gitignore.
