### PR TITLE
app-dir support array

### DIFF
--- a/src/Jlapp/Swaggervel/routes.php
+++ b/src/Jlapp/Swaggervel/routes.php
@@ -18,7 +18,15 @@ Route::any(Config::get('swaggervel.doc-route').'/{page?}', function($page='api-d
 
 Route::get(Config::get('swaggervel.api-docs-route'), function() {
     if (Config::get('swaggervel.generateAlways')) {
-        $appDir = base_path()."/".Config::get('swaggervel.app-dir');
+        $dir = Config::get('swaggervel.app-dir');
+        if(is_string($dir)) {
+            $appDir = base_path()."/".$dir;
+        } else {
+            $appDir = [];
+            foreach($dir as $d) {
+                $appDir[] = base_path()."/".$d;
+            }
+        }
         $docDir = Config::get('swaggervel.doc-dir');
 
         if (!File::exists($docDir) || is_writable($docDir)) {


### PR DESCRIPTION
Sometimes, the `model` and `api` don't in one folder, so the app-dir should support array.
