### PR TITLE
Fix issue with non-required options - Laravel 4

### DIFF
--- a/public/lib/swagger.js
+++ b/public/lib/swagger.js
@@ -932,8 +932,11 @@ SwaggerOperation.prototype.urlify = function(args) {
         url = url.replace(reg, this.encodePathParam(args[param.name]));
         delete args[param.name];
       }
-      else
-        throw "" + param.name + " is a required path param.";
+      else {
+          var reg = new RegExp('\{' + param.name + '[^\}]*\}', 'gi');
+          url = url.replace(reg, "");
+          delete args[param.name];
+      }
     }
   }
 


### PR DESCRIPTION
The problem occurs when you add a @SWG\Parameter that has the "required = false" but the Swagger frontend shows that it is a required field and it is not possible to execute "Try it" button without adding something in non-required field. This fix will solve the problem and it will be possible to execute the request without filling the non-required fields.