### PR TITLE
Compatibility with Laravel 5.4

### DIFF
--- a/src/Jlapp/Swaggervel/routes.php
+++ b/src/Jlapp/Swaggervel/routes.php
@@ -48,8 +48,8 @@ Route::get(Config::get('swaggervel.api-docs-route'), function() {
         Request::setTrustedProxies(array($proxy));
     }
 
-    Blade::setEscapedContentTags('{{{', '}}}');
-    Blade::setContentTags('{{', '}}');
+//     Blade::setEscapedContentTags('{{{', '}}}');
+//     Blade::setContentTags('{{', '}}');
 
     //need the / at the end to avoid CORS errors on Homestead systems.
     $response = response()->view('swaggervel::index', array(


### PR DESCRIPTION
Removal of undefined methods setEscapedContentTags and setContentTags methods on Blade Facade.